### PR TITLE
Dirty hack

### DIFF
--- a/src/carousel.jsx
+++ b/src/carousel.jsx
@@ -45,7 +45,9 @@ export default class Carousel extends Component {
         items: items,
         offset: newOffset
       },
-      () => {this.startTransition(direction); console.log(this.state)}
+      () => {
+        window.setTimeout(() => this.startTransition(direction), 10); console.log(this.state);
+      }
     );
   }
 


### PR DESCRIPTION
The problem originates in the way React modifies DOM tree: moving to next page just appends a new `Carousel__slide` node into container. While moving backwards rebuilds the whole list content. This results in a ton of reflows, resetting the margin to `auto` along the lines — which breaks the transition.
